### PR TITLE
Fix invalid YAML syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ example:
 ```yaml
 templates:
   kvm-openjdk-7u51:
-    skip_login = False
-    login_user = ADMIN
-    login_endpoint = rpc/WEBSES/create.asp
-    allow_insecure_ssl = False
-    user_login_attribute_name = WEBVAR_USERNAME
-    password_login_attribute_name = WEBVAR_PASSWORD
-    send_post_data_as_json = False
-    session_cookie_key = SessionCookie
-    download_endpoint = Java/jviewer.jnlp
-    java_version = 7u51
-    format_jnlp = False
+    skip_login: False
+    login_user: ADMIN
+    login_endpoint: rpc/WEBSES/create.asp
+    allow_insecure_ssl: False
+    user_login_attribute_name: WEBVAR_USERNAME
+    password_login_attribute_name: WEBVAR_PASSWORD
+    send_post_data_as_json: False
+    session_cookie_key: SessionCookie
+    download_endpoint: Java/jviewer.jnlp
+    java_version: 7u51
+    format_jnlp: False
 ```
 
 -   `skip_login`: Skip the login to the KVM host (should be `False` in most cases). If the login is skipped, you can


### PR DESCRIPTION
The previous example config gave an error:
```
Traceback (most recent call last):
  File "/usr/bin/nojava-ipmi-kvm", line 33, in <module>
    sys.exit(load_entry_point('nojava-ipmi-kvm==0.9.0', 'console_scripts', 'nojava-ipmi-kvm')())
  File "/usr/lib/python3.8/site-packages/nojava_ipmi_kvm/cli.py", line 130, in main
    host_config = config[args.hostname]
  File "/usr/lib/python3.8/site-packages/nojava_ipmi_kvm/config.py", line 222, in __getitem__
    for k, v in self._config_dict["templates"][raw_host["based_on"]].items():
AttributeError: 'str' object has no attribute 'items'
```
Key-value pairs are separated by `:` in YAML.