### PR TITLE
Fix Docker Container Port Parsing

### DIFF
--- a/nojava_ipmi_kvm/kvm.py
+++ b/nojava_ipmi_kvm/kvm.py
@@ -340,7 +340,7 @@ async def start_kvm_container(
                     add_sudo_if_configured(["docker", "port", DOCKER_CONTAINER_NAME]), stderr=subprocess_output
                 )
                 .strip()
-                .split(b":")[1]
+                .split(b"\n")[0].split(b":")[1]
             )
             break
         except (IndexError, ValueError):


### PR DESCRIPTION
When IPv4 and IPv6 is enabled in a host, the port parsing breaks while using the latest docker versions.

This was tested in a MacOS host with Docker version 20.10.7, build f0df350 