### PR TITLE
Opt-in legacy AMI JAR signatures for sandboxed KVM child

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,29 @@ zplug install
 
 Clone this repository and source `nojava_ipmi_kvm_completion.plugin.zsh` in your `.zshrc`.
 
+## Legacy AMI firmware (opt-in)
+
+Some AMI MegaRAC BMCs (Supermicro X9/X10, ASUS ASMB8) ship `JViewer.jar` signed with legacy algorithms and HTTPS certificates that modern OpenJDK builds reject inside the KVM child container.
+
+Opt-in template flags (default **off**) pass environment variables to the ephemeral `sciapp/nojava-ipmi-kvm` child only:
+
+| YAML key | Child env | Effect |
+|---|---|---|
+| `allow_legacy_jar_signatures: true` | `ALLOW_LEGACY_JAR_SIGNATURES=true` | Allow MD5 in `jdk.jar.disabledAlgorithms` |
+| `allow_insecure_jnlp_certs: true` | `ALLOW_INSECURE_JNLP_CERTS=true` | IcedTea `deployment.security.itw.ignorecertissues` |
+| (manual) | `ALLOW_LEGACY_AMI_JARS=true` | Both flags in the child image |
+
+Example:
+
+```yaml
+templates:
+  ami-megarac-openjdk-8:
+    allow_legacy_jar_signatures: true
+    allow_insecure_jnlp_certs: true
+    download_endpoint: Java/jviewer.jnlp
+    java_version: 8u242
+```
+
 ## Acknowledgement
 
 -   Special thanks to @mheuwes for adding the new YAML config file format and adding HTML5 support!

--- a/docker/Dockerfile_openjdk-8
+++ b/docker/Dockerfile_openjdk-8
@@ -1,6 +1,11 @@
 FROM debian:stretch
 LABEL maintainer="Ingo Meyer <i.meyer@fz-juelich.de>"
 
+# Debian stretch is archived; keep apt working for CI and fresh builds.
+RUN sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+    sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 # Install needed packages and Java dependencies (second `apt-get install` call)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl eterm fluxbox net-tools procps python-numpy \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+# Opt-in legacy AMI JViewer support (ephemeral child container only).
+# ALLOW_LEGACY_AMI_JARS=true enables both ALLOW_LEGACY_JAR_SIGNATURES and ALLOW_INSECURE_JNLP_CERTS.
+allow_legacy_jar_signatures() {
+    local java_security="$1"
+    if [[ -f "${java_security}" ]]; then
+        sed -i '/^jdk\.jar\.disabledAlgorithms=/ s/MD5, //; s/, MD5//; s/ MD5//' "${java_security}"
+    fi
+}
+
+legacy_jar_signatures_enabled() {
+    [[ "${ALLOW_LEGACY_JAR_SIGNATURES:-false}" == "true" ]] || \
+        [[ "${ALLOW_LEGACY_AMI_JARS:-false}" == "true" ]]
+}
+
+insecure_jnlp_certs_enabled() {
+    [[ "${ALLOW_INSECURE_JNLP_CERTS:-false}" == "true" ]] || \
+        [[ "${ALLOW_LEGACY_AMI_JARS:-false}" == "true" ]]
+}
+
 read -r -s PASSWD
 echo "${PASSWD}" | /usr/local/bin/get_java_viewer -o /tmp/launch.jnlp "$@"
 return_code="$?"
@@ -19,6 +38,7 @@ if [[ "${JAVA_VERSION%-oracle}" != "${JAVA_VERSION}" ]]; then
     JAVA_VERSION="${JAVA_VERSION%-oracle}"
     JAVA_MAJOR_VERSION="${JAVA_VERSION%%u*}"
     JAVA_PATCH_LEVEL="${JAVA_VERSION#*u}"
+    ORACLE_JRE="/opt/oracle/jre1.${JAVA_MAJOR_VERSION}.0_${JAVA_PATCH_LEVEL}"
     mkdir -p /opt/oracle && \
     tar -C/opt/oracle/ -xvf "/opt/java_packages/${JAVA_VERSION}/jre-${JAVA_VERSION}-linux-x64.tar.gz" && \
     ln -s "/opt/oracle/jre1.${JAVA_MAJOR_VERSION}.0_${JAVA_PATCH_LEVEL}/bin/javaws" /usr/local/bin/javaws && \
@@ -28,6 +48,9 @@ if [[ "${JAVA_VERSION%-oracle}" != "${JAVA_VERSION}" ]]; then
     echo "deployment.security.level=MEDIUM" >> "/root/.java/deployment/deployment.properties" || return
     export PATH="/opt/oracle/jre1.${JAVA_MAJOR_VERSION}.0_${JAVA_PATCH_LEVEL}/bin:${PATH}"
     export JAVA_SECURITY_DIR="/root/.java/deployment/security"
+    if legacy_jar_signatures_enabled; then
+        allow_legacy_jar_signatures "${ORACLE_JRE}/lib/security/java.security"
+    fi
 else
     JAVA_VERSION="${JAVA_VERSION%-openjdk}"
     JAVA_MAJOR_VERSION="${JAVA_VERSION%%u*}"
@@ -46,6 +69,12 @@ else
     fi
     #itweb-settings set deployment.security.notinca.warning false
     itweb-settings set deployment.security.expired.warning false
+    if insecure_jnlp_certs_enabled; then
+        itweb-settings set deployment.security.itw.ignorecertissues true
+    fi
+    if legacy_jar_signatures_enabled; then
+        allow_legacy_jar_signatures "/etc/java-${JAVA_MAJOR_VERSION}-openjdk/security/java.security"
+    fi
     export JAVA_SECURITY_DIR="/root/.config/icedtea-web/security"
 fi
 mkdir -p "${JAVA_SECURITY_DIR}"

--- a/nojava_ipmi_kvm/config.py
+++ b/nojava_ipmi_kvm/config.py
@@ -108,13 +108,27 @@ class JavaHostConfig(HostConfig):
         download_endpoint="cgi/url_redirect.cgi?url_name=ikvm&url_type=jwsk",
         java_version="7u181",
         format_jnlp=False,
+        allow_legacy_jar_signatures=False,
+        allow_insecure_jnlp_certs=False,
         **kwargs,
     ):
-        # type: (Text, Text, Text, Text, bool, **Any) -> None
+        # type: (Text, Text, Text, Text, bool, bool, bool, **Any) -> None
         super().__init__(short_hostname, full_hostname, **kwargs)
         self._download_endpoint = download_endpoint
         self._java_version = java_version
         self._format_jnlp = format_jnlp
+        self._allow_legacy_jar_signatures = allow_legacy_jar_signatures
+        self._allow_insecure_jnlp_certs = allow_insecure_jnlp_certs
+
+    @property
+    def allow_legacy_jar_signatures(self):
+        # type: () -> bool
+        return self._allow_legacy_jar_signatures
+
+    @property
+    def allow_insecure_jnlp_certs(self):
+        # type: () -> bool
+        return self._allow_insecure_jnlp_certs
 
     @property
     def download_endpoint(self):

--- a/nojava_ipmi_kvm/kvm.py
+++ b/nojava_ipmi_kvm/kvm.py
@@ -234,6 +234,10 @@ def create_java_docker_args(host_config, login_password, selected_resolution):
         "-e",
         "KVM_HOSTNAME={}".format(host_config.full_hostname),
     ]
+    if host_config.allow_legacy_jar_signatures:
+        environment_variables.extend(["-e", "ALLOW_LEGACY_JAR_SIGNATURES=true"])
+    if host_config.allow_insecure_jnlp_certs:
+        environment_variables.extend(["-e", "ALLOW_INSECURE_JNLP_CERTS=true"])
     java_provider = "oraclejre" if host_config.java_version.endswith("-oracle") else "openjdk"
     java_major_version = host_config.java_version.split("u")[0]
 


### PR DESCRIPTION
## Summary

AMI MegaRAC JViewer on ASUS ASMB8-iKVM fails in the stock OpenJDK 8u242 child: the AMI code-signing certificate on `JViewer.jar` is expired and `jdk.jar.disabledAlgorithms` includes MD5. Without opt-in flags, javaws reports unsigned jars; with legacy allowances enabled in the child, JViewer connects.

This PR adds **opt-in, default-off** flags gated by child environment variables and optional host-template YAML (`allow_legacy_jar_signatures`, `allow_insecure_jnlp_certs`). Default behaviour is unchanged.

`docker/Dockerfile_openjdk-8` points stretch apt sources at `archive.debian.org` so the child image still builds when Debian stretch mirrors are unavailable.

README documents the flags and example YAML only (ASUS `EXTRNIP` / `download_endpoint` is documented in #39).

## Flags

| YAML key | Child env | Effect |
|---|---|---|
| `allow_legacy_jar_signatures: true` | `ALLOW_LEGACY_JAR_SIGNATURES=true` | Allow MD5 in `jdk.jar.disabledAlgorithms` |
| `allow_insecure_jnlp_certs: true` | `ALLOW_INSECURE_JNLP_CERTS=true` | IcedTea `deployment.security.itw.ignorecertissues` |

`ALLOW_LEGACY_AMI_JARS=true` remains supported as a convenience alias for both flags.

## Files

- `docker/entrypoint.sh` — apply JVM / IcedTea settings when flags are set
- `docker/Dockerfile_openjdk-8` — stretch `archive.debian.org` apt sources
- `nojava_ipmi_kvm/config.py` — parse template YAML keys
- `nojava_ipmi_kvm/kvm.py` — pass `-e` into the ephemeral child
- `README.md` — example YAML and env var reference

## Test plan

- [ ] Stock child, flags unset: reproduce javaws / weak-signature failure on ASMB8
- [ ] Both YAML flags enabled: full JViewer session inside child
- [ ] Flags unset on other BMC templates: no regression
- [ ] `docker build -f docker/Dockerfile_openjdk-8` succeeds on a clean runner

Tested on ASUS ASMB8-iKVM firmware 1.14.2. With flags disabled, failure reproduced. With both YAML keys enabled, noVNC session loads after connect.

Closes #36
