### PR TITLE
Document legacy AMI opt-in and ASUS EXTRNIP download_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ zplug install
 
 Clone this repository and source `nojava_ipmi_kvm_completion.plugin.zsh` in your `.zshrc`.
 
+## ASUS / AMI BMC without DNS hostname
+
+Some ASUS ASMB8 and similar BMCs return an invalid JNLP when the BMC has no DNS name. Use `EXTRNIP` in `download_endpoint`:
+
+```yaml
+download_endpoint: "Java/jviewer.jnlp?EXTRNIP=<bmc-ip>&JNLPSTR=JViewer"
+```
+
+Replace `<bmc-ip>` with the address clients use to reach the BMC.
+
 ## Acknowledgement
 
 -   Special thanks to @mheuwes for adding the new YAML config file format and adding HTML5 support!


### PR DESCRIPTION
## Summary

Documentation only — legacy AMI opt-in pointers and ASUS `EXTRNIP` `download_endpoint` notes for BMCs without a DNS hostname.

Complements #37 when implementation and deployment docs land in separate pull requests. This PR does not duplicate the opt-in flags table from #37.

## Contents

- When to enable `allow_legacy_jar_signatures` / `allow_insecure_jnlp_certs` (see #37 for the full table)
- `EXTRNIP` placeholder behaviour for JNLP download URLs
- Example ASMB8-iKVM host template:

```yaml
hosts:
  my-bmc:
    full_hostname: 10.0.0.9
    download_endpoint: "Java/jviewer.jnlp?EXTRNIP=10.0.0.9&JNLPSTR=JViewer"
    allow_legacy_jar_signatures: true
    allow_insecure_jnlp_certs: true
```

Tested on ASUS ASMB8-iKVM firmware 1.14.2.
